### PR TITLE
Changed to Base AMI with Docker (PHNX-566)

### DIFF
--- a/amis/aws-linux-hvm/phoenix-webui.json
+++ b/amis/aws-linux-hvm/phoenix-webui.json
@@ -1,5 +1,6 @@
 {
   "variables": {
+    "source_ami": "ami-48d1fc32",
     "aws_access_key": "",
     "aws_secret_key": "",
     "aws_session_token": "",
@@ -22,7 +23,7 @@
         "region": "{{user `aws_region`}}",
         "associate_public_ip_address": "{{user `aws_associate_public_ip_address`}}",
         "security_group_id": "{{user `aws_security_group`}}",
-        "source_ami": "ami-4fffc834",
+        "source_ami": "{{user `source_ami`}}",
         "ssh_username": "ec2-user",
         "type": "amazon-ebs",
         "ena_support": "{{user `aws_ena_support`}}",

--- a/amis/aws-linux-hvm/scripts/phoenix-webui.sh
+++ b/amis/aws-linux-hvm/scripts/phoenix-webui.sh
@@ -5,12 +5,14 @@ sleep 20
 # Remove old Java
 sudo yum remove -y java-1.7.0-openjdk
 
-# Install Java, Docker, and Git
-sudo yum install -y docker git java-1.8.0
+# Install Java and Git
+# This script assumes Docker is baked into the AMI
+sudo yum install -y git java-1.8.0
 
 # Configure Docker for ephemeral storage
 sudo mkdir -p /media/ephemeral0/docker
 echo "OPTIONS=\"\$OPTIONS -g /media/ephemeral0/docker\"" | sudo tee -a /etc/sysconfig/docker
+sudo chkconfig docker on
 
 # Install docker-compose
 dockerComposeVersion=1.16.1


### PR DESCRIPTION
Updated the base AMI to use an AWS HVM with Docker pre-installed.

Updated the build script with a line that should start docker on boot.

Updated phoenix-webui.json so the base AMI ID is now a variable that can be easily changed.

https://centeredge.atlassian.net/browse/PHNX-566