### PR TITLE
Update Windows agent for Stage (STAGE-3284)

### DIFF
--- a/amis/windows/scripts/aws-windows.userdata
+++ b/amis/windows/scripts/aws-windows.userdata
@@ -16,7 +16,7 @@ winrm set winrm/config/winrs '@{MaxShellsPerUser="0"}'
 winrm set winrm/config '@{MaxTimeoutms="7200000"}'
 winrm set winrm/config/service '@{AllowUnencrypted="true"}'
 winrm set winrm/config/service/auth '@{Basic="true"}'
-winrm set winrm/config/service/auth '@{CredSSP="true"}'
+winrm set winrm/config/service/auth '@{CredSSP="false"}'
 winrm set winrm/config/client '@{TrustedHosts="*"}'
 
 

--- a/amis/windows/scripts/windows-install-packages.ps1
+++ b/amis/windows/scripts/windows-install-packages.ps1
@@ -82,6 +82,10 @@ if (![string]::IsNullOrWhiteSpace($env:packages)) {
         } else {
             &"choco" install $packageName --yes
         }
+
+        if ($LASTEXITCODE -ne 0) {
+          exit $LASTEXITCODE
+        }
     }
 }
 

--- a/amis/windows/scripts/windows10sdk.ps1
+++ b/amis/windows/scripts/windows10sdk.ps1
@@ -3,3 +3,8 @@ $ErrorActionPreference = 'Stop'
 Invoke-WebRequest -UseBasicParsing http://download.microsoft.com/download/2/1/2/2122BA8F-7EA6-4784-9195-A8CFB7E7388E/StandaloneSDK/sdksetup.exe -OutFile sdksetup.exe
 
 Start-Process -FilePath "sdksetup.exe" -ArgumentList /Quiet, /NoRestart, /Log, c:\install_logs\sdksetup.log -NoNewWindow -Wait
+
+& ${env:windir}\microsoft.net\framework\v4.0.30319\ngen.exe update /force /queue
+& ${env:windir}\microsoft.net\framework64\v4.0.30319\ngen.exe update /force /queue
+& ${env:windir}\microsoft.net\framework\v4.0.30319\ngen.exe executequeueditems
+& ${env:windir}\microsoft.net\framework64\v4.0.30319\ngen.exe executequeueditems

--- a/amis/windows/windows-msbuild2017.json
+++ b/amis/windows/windows-msbuild2017.json
@@ -13,7 +13,7 @@
     "aws_userdata_file": "amis/windows/scripts/aws-windows.userdata",
     "repository": "",
     "package_type": "",
-    "packages": "git jre8",
+    "packages": "git git-lfs jre8",
     "upgrade": "",
     "nuget_version": "4.5.1"
   },
@@ -95,6 +95,12 @@
         "NUGET_VERSION={{user `nuget_version`}}"
       ],
       "pause_before": "30s"
+    },
+    {
+      "type":"powershell",
+      "inline": [
+        "git config --system --unset credential.helper"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Motivation
----------
Windows agent for Jenkins isn't working effectively.

Modifications
-------------
Disable CredSSP auth for WinRM, as this is breaking Jenkins ability to
connect to the agent.

Add detection of failed Chocolatey package installs.

Perform ngen after installations to improve startup performance.

Include git-lfs for large file handling in Git.

Disable the Git for Windows credential helper to fix Git speed issues
when running on an agent with no UI.

https://centeredge.atlassian.net/browse/STAGE-3284
