### PR TITLE
Windows agent support for RevNu (STAGE-3334)

### DIFF
--- a/amis/windows/scripts/buildtools2017.ps1
+++ b/amis/windows/scripts/buildtools2017.ps1
@@ -14,12 +14,12 @@ Start-Process vs_BuildTools.exe -ArgumentList `
     '--quiet', '--norestart', '--nocache' `
     -NoNewWindow -Wait
 
-setx /M PATH $(${Env:PATH} + ";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin\")
+setx /M PATH $(${Env:PATH} + ";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin\;${Env:ProgramFiles}\dotnet\")
 
 # Install .NET Framework targeting packs
 Add-Type -AssemblyName System.IO.Compression.FileSystem
 
-@('4.7.1') | ForEach-Object {
+@('4.5.2', '4.7.1') | ForEach-Object {
     Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip -OutFile referenceassemblies.zip
     [System.IO.Compression.ZipFile]::ExtractToDirectory("referenceassemblies.zip", "${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\")
     Remove-Item -Force referenceassemblies.zip

--- a/amis/windows/scripts/windows10sdk.ps1
+++ b/amis/windows/scripts/windows10sdk.ps1
@@ -3,8 +3,3 @@ $ErrorActionPreference = 'Stop'
 Invoke-WebRequest -UseBasicParsing http://download.microsoft.com/download/2/1/2/2122BA8F-7EA6-4784-9195-A8CFB7E7388E/StandaloneSDK/sdksetup.exe -OutFile sdksetup.exe
 
 Start-Process -FilePath "sdksetup.exe" -ArgumentList /Quiet, /NoRestart, /Log, c:\install_logs\sdksetup.log -NoNewWindow -Wait
-
-& ${env:windir}\microsoft.net\framework\v4.0.30319\ngen.exe update /force /queue
-& ${env:windir}\microsoft.net\framework64\v4.0.30319\ngen.exe update /force /queue
-& ${env:windir}\microsoft.net\framework\v4.0.30319\ngen.exe executequeueditems
-& ${env:windir}\microsoft.net\framework64\v4.0.30319\ngen.exe executequeueditems


### PR DESCRIPTION
Motivation
----------
RevNu can't currently build on the Windows build agent.

Modifications
-------------
Install .NET 4.5.2 reference assemblies.

Ensure that .NET Core CLI is in the path, which allows .NET Core style
csproj files to work. Without this the MSBuild SDK resolver can't find
the right SDK files.

Removed NGEN because this was causing lots of inconsistencies building
the new AMI.

https://centeredge.atlassian.net/browse/STAGE-3334
