### PR TITLE
Add Jenkins agent for MSBuild 2019 (ADV-15268)

### DIFF
--- a/amis/windows/scripts/buildtools2017.ps1
+++ b/amis/windows/scripts/buildtools2017.ps1
@@ -18,41 +18,12 @@ Start-Process $vsbuildtools -ArgumentList `
     '--quiet', '--norestart', '--nocache' `
     -NoNewWindow -Wait
 
-setx /M PATH $(${Env:PATH} + ";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin\;${Env:ProgramFiles}\dotnet\")
-
-# Install .NET Framework targeting packs
-Add-Type -AssemblyName System.IO.Compression.FileSystem
-
-if (-not (Test-Path "${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\")) {
-    New-Item -ItemType Directory "${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\" | Out-Null
-}
-
-@('4.0', '4.5.2', '4.6.2', '4.7.2') | ForEach-Object {
-    $tempFolder = Join-Path ${env:TEMP} "referenceassemblies"
-    New-Item -ItemType Directory $tempFolder | Out-Null
-
-    Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip -OutFile referenceassemblies.zip
-    [System.IO.Compression.ZipFile]::ExtractToDirectory("referenceassemblies.zip", $tempFolder)
-    Remove-Item -Force referenceassemblies.zip
-
-    Get-ChildItem $tempFolder | ForEach-Object {
-        $destination = Join-Path "${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\" $_.Name
-
-        if (Test-Path $destination) {
-            Remove-Item $destination -Recurse -Force
-        }
-
-        Move-Item $_.FullName -Destination "${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\" -Force
-    }
-
-    Remove-Item $tempFolder -Force -Recurse -ErrorAction SilentlyContinue
+if (${env:set_msbuild2017_path} -ne "false") {
+    setx /M PATH $(${Env:PATH} + ";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin\;${Env:ProgramFiles}\dotnet\")
 }
 
 # Install .NET Core SDK 2.2 (.1xx series for MSBuild 2017 compatibility)
-choco install -y dotnetcore-sdk --version=2.2.105 --no-progress
+choco install -y dotnetcore-sdk --version=2.2.107 --no-progress
 if ($LASTEXITCODE -ne 0) {
     exit $LASTEXITCODE
 }
-
-# Install .NET 3.5, needed for some WiX tools
-Install-WindowsFeature NET-Framework-Core

--- a/amis/windows/scripts/buildtools2019.ps1
+++ b/amis/windows/scripts/buildtools2019.ps1
@@ -1,0 +1,14 @@
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue' # Speeds up download
+
+# Install MSBuild
+
+$vsbuildtools = Join-Path ${env:TEMP} vs_BuildTools2019.exe
+Invoke-WebRequest -UseBasicParsing https://aka.ms/vs/16/release/vs_BuildTools.exe -OutFile $vsbuildtools
+
+# .NET Core skip first time experience, Installer won't detect DOTNET_SKIP_FIRST_TIME_EXPERIENCE if ENV is used, must use setx /M
+setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1
+
+Start-Process $vsbuildtools -ArgumentList '--add', 'Microsoft.VisualStudio.Workload.MSBuildTools', '--add', 'Microsoft.VisualStudio.Workload.NetCoreBuildTools', '--add', 'Microsoft.VisualStudio.Workload.WebBuildTools', '--add', 'Microsoft.VisualStudio.Workload.VCTools', '--add', 'Microsoft.VisualStudio.Workload.VisualStudioExtensionBuildTools', '--quiet', '--norestart', '--nocache' -NoNewWindow -Wait
+
+setx /M PATH $(${Env:PATH} + ";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\;${Env:ProgramFiles}\dotnet\")

--- a/amis/windows/scripts/net-3.5.ps1
+++ b/amis/windows/scripts/net-3.5.ps1
@@ -1,0 +1,2 @@
+# Install .NET 3.5, needed for some WiX tools
+Install-WindowsFeature NET-Framework-Core

--- a/amis/windows/scripts/net-reference-assemblies.ps1
+++ b/amis/windows/scripts/net-reference-assemblies.ps1
@@ -1,0 +1,27 @@
+# Install .NET Framework targeting packs
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+if (-not (Test-Path "${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\")) {
+    New-Item -ItemType Directory "${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\" | Out-Null
+}
+
+@('4.0', '4.5.2', '4.6.2', '4.7.2') | ForEach-Object {
+    $tempFolder = Join-Path ${env:TEMP} "referenceassemblies"
+    New-Item -ItemType Directory $tempFolder | Out-Null
+
+    Invoke-WebRequest -UseBasicParsing https://dotnetbinaries.blob.core.windows.net/referenceassemblies/v${_}.zip -OutFile referenceassemblies.zip
+    [System.IO.Compression.ZipFile]::ExtractToDirectory("referenceassemblies.zip", $tempFolder)
+    Remove-Item -Force referenceassemblies.zip
+
+    Get-ChildItem $tempFolder | ForEach-Object {
+        $destination = Join-Path "${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\" $_.Name
+
+        if (Test-Path $destination) {
+            Remove-Item $destination -Recurse -Force
+        }
+
+        Move-Item $_.FullName -Destination "${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\" -Force
+    }
+
+    Remove-Item $tempFolder -Force -Recurse -ErrorAction SilentlyContinue
+}

--- a/amis/windows/windows-docker.json
+++ b/amis/windows/windows-docker.json
@@ -36,7 +36,8 @@
         "amis/windows/scripts/docker.ps1",
         "amis/windows/scripts/windows-install-packages.ps1",
         "amis/windows/scripts/windows-nuget.ps1",
-        "amis/windows/scripts/buildtools2017.ps1"
+        "amis/windows/scripts/buildtools2017.ps1",
+        "amis/windows/scripts/net-reference-assemblies.ps1"
       ],
       "environment_vars": [
         "repository={{user `repository`}}",

--- a/amis/windows/windows-msbuild2019.json
+++ b/amis/windows/windows-msbuild2019.json
@@ -6,16 +6,16 @@
     "aws_region": "us-east-1",
     "aws_winrm_username": "Administrator",
     "aws_instance_type": "t2.large",
-    "aws_target_ami": "jenkins-agent-windows-buildtools2017",
+    "aws_target_ami": "jenkins-agent-windows-buildtools2019",
     "aws_security_group": "",
     "aws_associate_public_ip_address": "true",
     "aws_ena_support": "true",
     "aws_userdata_file": "amis/windows/scripts/aws-windows.userdata",
     "repository": "",
     "package_type": "",
-    "packages": "git git-lfs jre8 vswhere nodejs.8.16.0",
+    "packages": "git git-lfs jre8 vswhere nodejs.12.13.1",
     "upgrade": "",
-    "nuget_version": "4.9.4"
+    "nuget_version": "5.4.0"
   },
 
   "builders": [
@@ -62,9 +62,9 @@
       ],
 
       "tags": {
-        "packages": "{{user `packages`}} msbuild2017 windows10sdk"
+        "packages": "{{user `packages`}} msbuild2017 msbuild2019 windows10sdk"
       },
-      "run_tags": {"packages": "{{user `packages`}} msbuild2017 windows10sdk"}
+      "run_tags": {"packages": "{{user `packages`}} msbuild2017 msbuild2019 windows10sdk"}
     }
   ],
 
@@ -94,6 +94,7 @@
         "amis/windows/scripts/windows-install-packages.ps1",
         "amis/windows/scripts/windows-nuget.ps1",
         "amis/windows/scripts/buildtools2017.ps1",
+        "amis/windows/scripts/buildtools2019.ps1",
         "amis/windows/scripts/net-reference-assemblies.ps1",
         "amis/windows/scripts/windows81sdk.ps1",
         "amis/windows/scripts/windows10sdk.ps1",
@@ -104,7 +105,8 @@
         "package_type={{user `package_type`}}",
         "packages={{user `packages`}}",
         "upgrade={{user `upgrade`}}",
-        "NUGET_VERSION={{user `nuget_version`}}"
+        "NUGET_VERSION={{user `nuget_version`}}",
+        "set_msbuild2017_path=false"
       ]
     },
     {


### PR DESCRIPTION
Motivation
----------
We'd like new stuff on our Windows build agents, but want to leave the
old stuff there, too.

Modifications
-------------
Split some things into multiple files so we can only install them once
in different combinations.

Moved .NET 3.5 install up in the process because it was failing later.

Upgrade to NodeJS 12, add MSBuild 2019 (which includes .NET Core 3.1).

https://centeredge.atlassian.net/browse/ADV-15268
