### PR TITLE
Update on prem agents to MSBuild 2019 (ADV-15270)

### DIFF
--- a/amis/windows/windows-docker.json
+++ b/amis/windows/windows-docker.json
@@ -6,9 +6,9 @@
     "password": "Centeredge123",
     "repository": "",
     "package_type": "",
-    "packages": "git git-lfs jre8 vswhere nodejs.8.16.0",
+    "packages": "git git-lfs jre8 vswhere nodejs.12.13.1",
     "upgrade": "",
-    "nuget_version": "4.9.4"
+    "nuget_version": "5.4.0"
   },
   "builders": [
     {
@@ -37,6 +37,7 @@
         "amis/windows/scripts/windows-install-packages.ps1",
         "amis/windows/scripts/windows-nuget.ps1",
         "amis/windows/scripts/buildtools2017.ps1",
+        "amis/windows/scripts/buildtools2019.ps1",
         "amis/windows/scripts/net-reference-assemblies.ps1"
       ],
       "environment_vars": [


### PR DESCRIPTION
Motivation
----------
We'd like new stuff on our Windows build agents, but want to leave the
old stuff there, too.

Modifications
-------------
Upgrade to NodeJS 12, add MSBuild 2019 (which includes .NET Core 3.1).

https://centeredge.atlassian.net/browse/ADV-15270
