### PR TITLE
Update Agent to Install .Net 4.8 (DO-788)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Set-AWSCredential -AccessKey YourAccessKeyFromStep1 -SecretKey YourSecretKeyFrom
 Set-AWSCredential -SourceProfile myCredentials -RoleArn arn:aws:iam::097130181434:role/PowerUser -MfaSerial arn:aws:iam::yourmfaserialnumber -StoreAs myRoleProfile
 ```
 ```powershell
-Set-WSCredential myRoleProfile
+Set-AWSCredential myRoleProfile
 ```
 
 4. Verify Setup with:

--- a/amis/windows/scripts/net-reference-assemblies.ps1
+++ b/amis/windows/scripts/net-reference-assemblies.ps1
@@ -5,7 +5,7 @@ if (-not (Test-Path "${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Fra
     New-Item -ItemType Directory "${Env:ProgramFiles(x86)}\Reference Assemblies\Microsoft\Framework\.NETFramework\" | Out-Null
 }
 
-@('4.0', '4.5.2', '4.6.2', '4.7.2') | ForEach-Object {
+@('4.0', '4.5.2', '4.6.2', '4.7.2', '4.8') | ForEach-Object {
     $tempFolder = Join-Path ${env:TEMP} "referenceassemblies"
     New-Item -ItemType Directory $tempFolder | Out-Null
 

--- a/amis/windows/scripts/windows-configure-chocolatey.ps1
+++ b/amis/windows/scripts/windows-configure-chocolatey.ps1
@@ -1,3 +1,5 @@
+# Update PS to allow TLS1.2
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
 
 # Install Chocolatey.
 Invoke-WebRequest https://chocolatey.org/install.ps1 -UseBasicParsing | Invoke-Expression

--- a/amis/windows/windows-msbuild2017.json
+++ b/amis/windows/windows-msbuild2017.json
@@ -44,7 +44,7 @@
         "most_recent": true
       },
 
-      "ami_name": "{{user `aws_target_ami` | clean_ami_name}}-{{timestamp}}",
+      "ami_name": "{{user `aws_target_ami` | clean_resource_name}}-{{timestamp}}",
 
       "associate_public_ip_address": "{{user `aws_associate_public_ip_address`}}",
 

--- a/amis/windows/windows-msbuild2019.json
+++ b/amis/windows/windows-msbuild2019.json
@@ -44,7 +44,7 @@
         "most_recent": true
       },
 
-      "ami_name": "{{user `aws_target_ami` | clean_ami_name}}-{{timestamp}}",
+      "ami_name": "{{user `aws_target_ami` | clean_resource_name}}-{{timestamp}}",
 
       "associate_public_ip_address": "{{user `aws_associate_public_ip_address`}}",
 


### PR DESCRIPTION
Motivation
------------
In preparation of .NET 5 we are upgrading advantage to .NET 4.8, the build system needs the SDK installed

Modification
-------------
 - Added 4.8 to net reference assemblies
 - Updated chocolatey file to allow TLS 1.2
 - Updated clean_ami_name to clean_resource_name
 - Fixed typo in readme

https://centeredge.atlassian.net/browse/DO-788
