### PR TITLE
Add name/base ami as labels to linux build agents (DO-832)

### DIFF
--- a/amis/aws-linux-hvm/git-docker.json
+++ b/amis/aws-linux-hvm/git-docker.json
@@ -47,6 +47,10 @@
         "encrypt_boot": true,
         "run_tags": {
           "Name": "Packer jenkins-linux-git-docker"
+        },
+        "tags": {
+          "Name": "Jenkins Agent Linux",
+          "Base_AMI_Name": "{{ .SourceAMIName }}"
         }
     }
   ],


### PR DESCRIPTION
Motivation:
----------
Had to update the linux build agents to latest ami versions, while I was at it added the name and source ami tags for convenience 

Modifications:
----------
* Added tags to linux build agent packer config
* New base ami created as `ami-08b160fd719bef1cd`

Results:
----------
* New base ami exists and is being used in jenkins

https://centeredge.atlassian.net/browse/DO-832
