### PR TITLE
Add .NET 5.0 to Windows agents (DO-987)

### DIFF
--- a/amis/windows/scripts/net50.ps1
+++ b/amis/windows/scripts/net50.ps1
@@ -1,0 +1,5 @@
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
+Invoke-WebRequest -UseBasicParsing -Uri https://download.visualstudio.microsoft.com/download/pr/2892493e-df43-409e-af68-8b14aa75c029/53156c889fc08f01b7ed8d7135badede/dotnet-sdk-5.0.100-win-x64.exe -OutFile .\dotnet-sdk-5.0.100-win-x64.exe
+
+.\dotnet-sdk-5.0.100-win-x64.exe /install /quiet /norestart

--- a/amis/windows/scripts/windows-nuget.ps1
+++ b/amis/windows/scripts/windows-nuget.ps1
@@ -2,6 +2,8 @@ $ErrorActionPreference = 'Stop'
 
 New-Item -Type Directory $Env:ProgramFiles\NuGet | Out-Null
 
+[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+
 Invoke-WebRequest -UseBasicParsing https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe -OutFile $Env:ProgramFiles\NuGet\nuget.exe
 
 [Environment]::SetEnvironmentVariable("PATH", ${Env:PATH} + ";${Env:ProgramFiles}\NuGet\", "Machine")

--- a/amis/windows/windows-msbuild2019.json
+++ b/amis/windows/windows-msbuild2019.json
@@ -15,7 +15,7 @@
     "package_type": "",
     "packages": "git git-lfs jre8 vswhere nodejs.12.13.1",
     "upgrade": "",
-    "nuget_version": "5.4.0"
+    "nuget_version": "5.8.0"
   },
 
   "builders": [
@@ -95,6 +95,7 @@
         "amis/windows/scripts/windows-nuget.ps1",
         "amis/windows/scripts/buildtools2017.ps1",
         "amis/windows/scripts/buildtools2019.ps1",
+        "amis/windows/scripts/net50.ps1",
         "amis/windows/scripts/net-reference-assemblies.ps1",
         "amis/windows/scripts/windows81sdk.ps1",
         "amis/windows/scripts/windows10sdk.ps1",


### PR DESCRIPTION
Motivation
----------
C# 9 goodness.

Modifications
-------------
Adjust TLS settings to be modern, and add .NET 5.0 to the AMI build
scripts.

https://centeredge.atlassian.net/browse/DO-987
