### PR TITLE
Add github CLI to build agents(ADV-17270)

### DIFF
--- a/amis/windows/windows-docker.json
+++ b/amis/windows/windows-docker.json
@@ -6,7 +6,7 @@
     "password": "Centeredge123",
     "repository": "",
     "package_type": "",
-    "packages": "git git-lfs jre8 vswhere nodejs.12.13.1",
+    "packages": "git git-lfs jre8 vswhere nodejs.12.13.1 gh",
     "upgrade": "",
     "nuget_version": "5.4.0"
   },

--- a/amis/windows/windows-docker.json
+++ b/amis/windows/windows-docker.json
@@ -6,7 +6,7 @@
     "password": "Centeredge123",
     "repository": "",
     "package_type": "",
-    "packages": "git git-lfs jre8 vswhere nodejs.12.13.1 gh",
+    "packages": "git git-lfs jre8 vswhere nodejs.12.13.1",
     "upgrade": "",
     "nuget_version": "5.4.0"
   },

--- a/amis/windows/windows-msbuild2019.json
+++ b/amis/windows/windows-msbuild2019.json
@@ -13,7 +13,7 @@
     "aws_userdata_file": "amis/windows/scripts/aws-windows.userdata",
     "repository": "",
     "package_type": "",
-    "packages": "git git-lfs jre8 vswhere nodejs.12.13.1",
+    "packages": "git git-lfs jre8 vswhere nodejs.12.13.1 gh",
     "upgrade": "",
     "nuget_version": "5.8.0"
   },


### PR DESCRIPTION
Motivation
------------
The current patching process can be inconsistent, PR patches pull from the commit, and merge patches pull from the PR descripion, since the commit uses the PR description when merging. GH CLI has a method for view the PR description we can use.

Modification
-------------
 - Added GH package

https://centeredge.atlassian.net/browse/ADV-17270
