### PR TITLE
Create script for github CLI(ADV-17291)

### DIFF
--- a/amis/windows/scripts/buildtools2019.ps1
+++ b/amis/windows/scripts/buildtools2019.ps1
@@ -11,4 +11,11 @@ setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1
 
 Start-Process $vsbuildtools -ArgumentList '--add', 'Microsoft.VisualStudio.Workload.MSBuildTools', '--add', 'Microsoft.VisualStudio.Workload.NetCoreBuildTools', '--add', 'Microsoft.VisualStudio.Workload.WebBuildTools', '--add', 'Microsoft.VisualStudio.Workload.VCTools', '--add', 'Microsoft.VisualStudio.Workload.VisualStudioExtensionBuildTools', '--quiet', '--norestart', '--nocache' -NoNewWindow -Wait
 
-setx /M PATH $(${Env:PATH} + ";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\;${Env:ProgramFiles}\dotnet\")
+if (${Env:PATH}.EndsWith(';')) {
+    $path = "${Env:PATH}${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\;${Env:ProgramFiles}\dotnet\"
+}
+else {
+    $path = "${Env:PATH};${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\;${Env:ProgramFiles}\dotnet\"
+}
+
+setx /M PATH $path

--- a/amis/windows/scripts/git-hub-cli.ps1
+++ b/amis/windows/scripts/git-hub-cli.ps1
@@ -1,0 +1,10 @@
+&"choco" install gh --yes --no-progress
+
+if (${Env:PATH}.EndsWith(';')) {
+    $path = "${Env:PATH}${Env:ProgramFiles(x86)}\GitHub CLI\"
+}
+else {
+    $path = "${Env:PATH};${Env:ProgramFiles(x86)}\GitHub CLI\"
+}
+
+setx /M PATH $path

--- a/amis/windows/scripts/windows-nuget.ps1
+++ b/amis/windows/scripts/windows-nuget.ps1
@@ -6,4 +6,11 @@ New-Item -Type Directory $Env:ProgramFiles\NuGet | Out-Null
 
 Invoke-WebRequest -UseBasicParsing https://dist.nuget.org/win-x86-commandline/v$Env:NUGET_VERSION/nuget.exe -OutFile $Env:ProgramFiles\NuGet\nuget.exe
 
-[Environment]::SetEnvironmentVariable("PATH", ${Env:PATH} + ";${Env:ProgramFiles}\NuGet\", "Machine")
+if (${Env:PATH}.EndsWith(';')) {
+    $path = "${Env:PATH}${Env:ProgramFiles}\NuGet\"
+}
+else {
+    $path = "${Env:PATH};${Env:ProgramFiles}\NuGet\"
+}
+
+[Environment]::SetEnvironmentVariable("PATH", $path, "Machine")

--- a/amis/windows/windows-msbuild2019.json
+++ b/amis/windows/windows-msbuild2019.json
@@ -13,45 +13,36 @@
     "aws_userdata_file": "amis/windows/scripts/aws-windows.userdata",
     "repository": "",
     "package_type": "",
-    "packages": "git git-lfs jre8 vswhere nodejs.12.13.1 gh",
+    "packages": "git git-lfs jre8 vswhere nodejs.12.13.1",
     "upgrade": "",
     "nuget_version": "5.8.0"
   },
-
   "builders": [
     {
       "type": "amazon-ebs",
-
       "access_key": "{{user `aws_access_key`}}",
       "secret_key": "{{user `aws_secret_key`}}",
       "token": "{{user `aws_session_token`}}",
-
       "communicator": "winrm",
       "winrm_username": "{{user `aws_winrm_username`}}",
       "user_data_file": "{{user `aws_userdata_file`}}",
-
       "region": "{{user `aws_region`}}",
-
       "instance_type": "{{user `aws_instance_type`}}",
-
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "hvm",
           "name": "Windows_Server-2012-R2_RTM-English-64Bit-Base-*",
           "root-device-type": "ebs"
         },
-        "owners": ["amazon"],
+        "owners": [
+          "amazon"
+        ],
         "most_recent": true
       },
-
       "ami_name": "{{user `aws_target_ami` | clean_resource_name}}-{{timestamp}}",
-
       "associate_public_ip_address": "{{user `aws_associate_public_ip_address`}}",
-
       "security_group_id": "{{user `aws_security_group`}}",
-
       "ena_support": "{{user `aws_ena_support`}}",
-
       "launch_block_device_mappings": [
         {
           "device_name": "/dev/sda1",
@@ -60,17 +51,17 @@
           "delete_on_termination": true
         }
       ],
-
       "tags": {
         "packages": "{{user `packages`}} msbuild2017 msbuild2019 windows10sdk"
       },
-      "run_tags": {"packages": "{{user `packages`}} msbuild2017 msbuild2019 windows10sdk"}
+      "run_tags": {
+        "packages": "{{user `packages`}} msbuild2017 msbuild2019 windows10sdk"
+      }
     }
   ],
-
   "provisioners": [
     {
-      "type":"powershell",
+      "type": "powershell",
       "elevated_user": "Administrator",
       "elevated_password": "{{ .WinRMPassword }}",
       "scripts": [
@@ -85,7 +76,7 @@
       "type": "windows-restart"
     },
     {
-      "type":"powershell",
+      "type": "powershell",
       "elevated_user": "Administrator",
       "elevated_password": "{{ .WinRMPassword }}",
       "scripts": [
@@ -111,7 +102,7 @@
       ]
     },
     {
-      "type":"powershell",
+      "type": "powershell",
       "inline": [
         "git config --system --unset credential.helper"
       ]


### PR DESCRIPTION
Motivation
------------
We need a script to install the guthub cli and add the path to the system variables, the gh cli installer only adds it to the user running it, with no way to specify other/all users/system. I also ran into an issue where multiple semi-colons can be chained together, this break setx, it will throw an error saying the default option cannot be specifed more than once. I added checks for semi colons in hopes it would prevent future issues.

Modification
-------------
 - Added script for git hub cli
 - Added checks for semicolons at the end of path

https://centeredge.atlassian.net/browse/ADV-17291
