### PR TITLE
End paths with semi-colons(ADV-17308)

### DIFF
--- a/amis/windows/scripts/buildtools2017.ps1
+++ b/amis/windows/scripts/buildtools2017.ps1
@@ -19,7 +19,7 @@ Start-Process $vsbuildtools -ArgumentList `
     -NoNewWindow -Wait
 
 if (${env:set_msbuild2017_path} -ne "false") {
-    setx /M PATH $(${Env:PATH} + ";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin\;${Env:ProgramFiles}\dotnet\")
+    setx /M PATH $(${Env:PATH} + ";${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin\;${Env:ProgramFiles}\dotnet\;")
 }
 
 # Install .NET Core SDK 2.2 (.1xx series for MSBuild 2017 compatibility)

--- a/amis/windows/scripts/buildtools2019.ps1
+++ b/amis/windows/scripts/buildtools2019.ps1
@@ -12,10 +12,10 @@ setx /M DOTNET_SKIP_FIRST_TIME_EXPERIENCE 1
 Start-Process $vsbuildtools -ArgumentList '--add', 'Microsoft.VisualStudio.Workload.MSBuildTools', '--add', 'Microsoft.VisualStudio.Workload.NetCoreBuildTools', '--add', 'Microsoft.VisualStudio.Workload.WebBuildTools', '--add', 'Microsoft.VisualStudio.Workload.VCTools', '--add', 'Microsoft.VisualStudio.Workload.VisualStudioExtensionBuildTools', '--quiet', '--norestart', '--nocache' -NoNewWindow -Wait
 
 if (${Env:PATH}.EndsWith(';')) {
-    $path = "${Env:PATH}${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\;${Env:ProgramFiles}\dotnet\"
+    $path = "${Env:PATH}${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\;${Env:ProgramFiles}\dotnet\;"
 }
 else {
-    $path = "${Env:PATH};${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\;${Env:ProgramFiles}\dotnet\"
+    $path = "${Env:PATH};${Env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\BuildTools\MSBuild\Current\Bin\;${Env:ProgramFiles}\dotnet\;"
 }
 
 setx /M PATH $path

--- a/amis/windows/scripts/git-hub-cli.ps1
+++ b/amis/windows/scripts/git-hub-cli.ps1
@@ -1,10 +1,10 @@
-&"choco" install gh --yes --no-progress
+& choco install gh --yes --no-progress
 
 if (${Env:PATH}.EndsWith(';')) {
-    $path = "${Env:PATH}${Env:ProgramFiles(x86)}\GitHub CLI\"
+    $path = "${Env:PATH}${Env:ProgramFiles(x86)}\GitHub CLI\;"
 }
 else {
-    $path = "${Env:PATH};${Env:ProgramFiles(x86)}\GitHub CLI\"
+    $path = "${Env:PATH};${Env:ProgramFiles(x86)}\GitHub CLI\;"
 }
 
 setx /M PATH $path

--- a/amis/windows/windows-msbuild2019.json
+++ b/amis/windows/windows-msbuild2019.json
@@ -83,6 +83,7 @@
         "amis/windows/scripts/aws-windows-2012-configure-ec2service.ps1",
         "amis/windows/scripts/windows-configure-chocolatey.ps1",
         "amis/windows/scripts/windows-install-packages.ps1",
+        "amis/windows/scripts/git-hub-cli.ps1",
         "amis/windows/scripts/windows-nuget.ps1",
         "amis/windows/scripts/buildtools2017.ps1",
         "amis/windows/scripts/buildtools2019.ps1",


### PR DESCRIPTION
Motivation
------------
Via further testing I noticed some inconsistencies with setx. If you don't end a path with a semi-colon, it adds a double quote at the end of the path, with a semi-colon, which causes issues with further calls to setx where you use the original path. To alleivate this, adding a semi-colon to the end prevents a double quote from added to the end.

Modification
-------------
 - Added semi-colons to end of paths

https://centeredge.atlassian.net/browse/ADV-17308
