### PR TITLE
Increase linux agent volume size (DO-1179)

### DIFF
--- a/amis/aws-linux-hvm/git-docker.json
+++ b/amis/aws-linux-hvm/git-docker.json
@@ -39,7 +39,7 @@
         "launch_block_device_mappings": [
           {
             "device_name": "/dev/xvda",
-            "volume_size": 50,
+            "volume_size": 100,
             "volume_type": "gp2",
             "delete_on_termination": true
           }


### PR DESCRIPTION
Motivation:
----------
Linux build agents running out of volume space

Modifications:
----------
* Increase volume space in packer build

Results:
----------
* Ran packer and created AMI `ami-0b1f35e9c1d96d830`

_NOTES: [Jenkins Cloud Configuration](https://jenkins.centeredgesoftware.com/configureClouds/) still needs updating, the previous agent images where almost a year old ( AMI `ami-08b160fd719bef1cd` ) Just noting in case we need to revert due to build issues_

https://centeredge.atlassian.net/browse/DO-1179
