### PR TITLE
Update jenkins linux agents to jvm 11 (DO-1445)

### DIFF
--- a/amis/aws-linux-hvm/scripts/git-docker.sh
+++ b/amis/aws-linux-hvm/scripts/git-docker.sh
@@ -4,12 +4,11 @@
 sudo yum remove -y java-1.7.0-openjdk
 
 # Install Java and Git
-# This script assumes Docker is baked into the AMI
 sudo yum update -y
-sudo yum install -y git git-lfs java-1.8.0
+sudo yum install -y git git-lfs
 
 # Install Docker
-sudo amazon-linux-extras install docker
+sudo amazon-linux-extras install docker java-openjdk11
 sudo systemctl enable docker
 
 # Ensure Docker access for ec2-user
@@ -17,5 +16,5 @@ sudo usermod -a -G docker ec2-user
 
 # Install docker-compose
 dockerComposeVersion=1.23.2
-sudo -i curl -L https://github.com/docker/compose/releases/download/$dockerComposeVersion/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+sudo -i curl -L https://github.com/docker/compose/releases/download/$dockerComposeVersion/docker-compose-"$(uname -s)"-"$(uname -m)" -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose


### PR DESCRIPTION
Motivation
----------
Update the installed jvm of linux agents from 8 to 11

Modifications
-------------
* Packer build scripts updated to install new jvm

https://centeredge.atlassian.net/browse/DO-1445
