### PR TITLE
Update OnPrem to node 16 build tools 22(ADV-18349)

### DIFF
--- a/amis/windows/windows-docker.json
+++ b/amis/windows/windows-docker.json
@@ -6,9 +6,9 @@
     "password": "Centeredge123",
     "repository": "",
     "package_type": "",
-    "packages": "git git-lfs jre8 vswhere nodejs.12.13.1",
+    "packages": "git git-lfs jre8 vswhere nodejs.16.10.0",
     "upgrade": "",
-    "nuget_version": "5.4.0"
+    "nuget_version": "5.8.0"
   },
   "builders": [
     {
@@ -38,6 +38,7 @@
         "amis/windows/scripts/windows-nuget.ps1",
         "amis/windows/scripts/buildtools2017.ps1",
         "amis/windows/scripts/buildtools2019.ps1",
+        "amis/windows/scripts/buildtools2022.ps1",
         "amis/windows/scripts/net-reference-assemblies.ps1"
       ],
       "environment_vars": [

--- a/amis/windows/windows-msbuild2022.json
+++ b/amis/windows/windows-msbuild2022.json
@@ -6,7 +6,7 @@
     "aws_region": "us-east-1",
     "aws_winrm_username": "Administrator",
     "aws_instance_type": "t2.large",
-    "aws_target_ami": "jenkins-agent-windows-buildtools2019",
+    "aws_target_ami": "jenkins-agent-windows-buildtools2022",
     "aws_security_group": "",
     "aws_associate_public_ip_address": "true",
     "aws_ena_support": "true",


### PR DESCRIPTION
Motivation
------------
We need to update the on prem agents to node 16 and build tools 2022 as well.

Modification
-------------
 - Added node 16/build tools 2022

https://centeredge.atlassian.net/browse/ADV-18349
