### PR TITLE
Upgrade Linux Agent Java Runtime (DO-1799)

### DIFF
--- a/amis/aws-linux-hvm/git-docker.json
+++ b/amis/aws-linux-hvm/git-docker.json
@@ -50,7 +50,8 @@
         },
         "tags": {
           "Name": "Jenkins Agent Linux",
-          "Base_AMI_Name": "{{ .SourceAMIName }}"
+          "Base_AMI_Name": "{{ .SourceAMIName }}",
+          "JDK": "java-openjdk11"
         }
     }
   ],

--- a/amis/aws-linux-hvm/scripts/git-docker.sh
+++ b/amis/aws-linux-hvm/scripts/git-docker.sh
@@ -1,18 +1,9 @@
 #!/bin/bash
 
-# Remove old Java
-sudo yum remove -y java-1.7.0-openjdk
-
-# Install Java and Git
-# This script assumes Docker is baked into the AMI
-sudo yum update -y
-sudo yum install -y git git-lfs java-1.8.0
-
-# Install Docker
-sudo amazon-linux-extras install docker
+sudo yum install -y git git-lfs
+sudo amazon-linux-extras install java-openjdk11 docker
+# Autostart / Ensure Docker access for ec2-user
 sudo systemctl enable docker
-
-# Ensure Docker access for ec2-user
 sudo usermod -a -G docker ec2-user
 
 # Install docker-compose


### PR DESCRIPTION
Motivation
----
Create new AMI for linux Jenkins agents with JDK 11 upgrade from previous JRE 8

Modifications
----
* Updated packer build scripts to install updated java runtime

Results
----
* AMI created with new `JDK` tag set to `java-openjdk11` in `centeredgedev` account
* AMI still needs testing against Jenkins Controller once that server is upgraded as well however instance launched, ssh'd into and verified the correct JDK version installed.


https://centeredge.atlassian.net/browse/DO-1799
