### PR TITLE
Up build volume size, hanging bulids (DO-2224)

### DIFF
--- a/amis/aws-linux-hvm/git-docker.json
+++ b/amis/aws-linux-hvm/git-docker.json
@@ -39,7 +39,7 @@
         "launch_block_device_mappings": [
           {
             "device_name": "/dev/xvda",
-            "volume_size": 100,
+            "volume_size": 200,
             "volume_type": "gp2",
             "delete_on_termination": true
           }


### PR DESCRIPTION
Motivation
---
Builds are hanging in jenkins, agents are running out of space.

Modification
---
* Upped volume on build agents (these are deleted on termination and should be short lived)

Result
---
Will need to leave and monitor progress for a couple days to see if it resolves the issue.

https://centeredge.atlassian.net/browse/DO-2224
