### PR TITLE
Upgrade jenkins linux agents JVM (DO-4077)

### DIFF
--- a/amis/aws-linux-hvm/git-docker.json
+++ b/amis/aws-linux-hvm/git-docker.json
@@ -22,11 +22,10 @@
 
         "source_ami_filter": {
           "filters": {
-            "virtualization-type": "hvm",
-            "name": "amzn2-ami-hvm-*-x86_64-gp2",
-            "root-device-type": "ebs"
+            "name": "al2023-ami-2023*",
+            "architecture": "x86_64"
           },
-          "owners": ["amazon"],
+          "owners": ["137112412989"],
           "most_recent": true
         },
 
@@ -40,7 +39,7 @@
           {
             "device_name": "/dev/xvda",
             "volume_size": 200,
-            "volume_type": "gp2",
+            "volume_type": "gp3",
             "delete_on_termination": true
           }
         ],
@@ -51,7 +50,7 @@
         "tags": {
           "Name": "Jenkins Agent Linux",
           "Base_AMI_Name": "{{ .SourceAMIName }}",
-          "JDK": "java-openjdk11"
+          "JDK": "java-17-amazon-corretto"
         }
     }
   ],

--- a/amis/aws-linux-hvm/scripts/git-docker.sh
+++ b/amis/aws-linux-hvm/scripts/git-docker.sh
@@ -3,7 +3,7 @@ sudo dnf install -y git git-lfs java-17-amazon-corretto docker
 sudo usermod -aG docker ec2-user
 sudo systemctl enable --now docker.service containerd.service
 
-dockerComposeVersion=v2.20.2
-sudo curl -sL https://github.com/docker/compose/releases/download/$dockerComposeVersion/docker-compose-linux-"$(uname -m)" -o /usr/local/bin/docker-compose
+# Install docker-compose
+dockerComposeVersion=1.23.2
+sudo -i curl -L https://github.com/docker/compose/releases/download/$dockerComposeVersion/docker-compose-linux-"$(uname -m)" -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose
-

--- a/amis/aws-linux-hvm/scripts/git-docker.sh
+++ b/amis/aws-linux-hvm/scripts/git-docker.sh
@@ -1,12 +1,9 @@
 #!/bin/bash
+sudo dnf install -y git git-lfs java-17-amazon-corretto docker
+sudo usermod -aG docker ec2-user
+sudo systemctl enable --now docker.service containerd.service
 
-sudo yum install -y git git-lfs
-sudo amazon-linux-extras install java-openjdk11 docker
-# Autostart / Ensure Docker access for ec2-user
-sudo systemctl enable docker
-sudo usermod -a -G docker ec2-user
-
-# Install docker-compose
-dockerComposeVersion=1.23.2
-sudo -i curl -L https://github.com/docker/compose/releases/download/$dockerComposeVersion/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+dockerComposeVersion=v2.20.2
+sudo curl -sL https://github.com/docker/compose/releases/download/$dockerComposeVersion/docker-compose-linux-"$(uname -m)" -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose
+


### PR DESCRIPTION
Motivation
---
JVM 11 is EOL soon, upgrade to JVM 17

Modification
---
* Updated version of java

Result
---
Build agent AMI created and new AMI id `ami-0ab69148e939f5888` is being used in jenkins server now

https://centeredge.atlassian.net/browse/DO-4077
